### PR TITLE
Add gitattibutes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Mark auto-generated GLAD code as vendored to exclude from language statistics
+ostov/src/glad.c linguist-vendored
+ostov/include/glad/glad.h linguist-vendored
+ostov/include/KHR/khrplatform.h linguist-vendored
+
+# Mark sandbox as documentation/example to focus stats on the core library
+sandbox/** linguist-documentation


### PR DESCRIPTION
## What?

GitHub falsely mistaken my repo primarily in C.

## Why?

The included `glad.h`, `glad.c`, `khrplatform.h` contains way more lines of code compared to my C++ codebase.

## How?

Added gitattibutes to clear out those 3 files.

## Testing?

None.

## Screenshots (optional)

None.

## Anything Else?

None.