### PR TITLE
docs: rename sandbox to examples and add demo application

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,5 @@ ostov/src/glad.c linguist-vendored
 ostov/include/glad/glad.h linguist-vendored
 ostov/include/KHR/khrplatform.h linguist-vendored
 
-# Mark sandbox as documentation/example to focus stats on the core library
-sandbox/** linguist-documentation
+# Mark examples as documentation/example to focus stats on the core library
+examples/** linguist-documentation

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ Thumbs.db
 # Ignore OpenGL requirement archives folder
 /openGL_requirement_archive/
 
-# Ignore local client/sandbox applications
-/sandbox/
+# Ignore local client/examples applications
+/examples/bin/
+/examples/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # Add Subdirectories
 add_subdirectory(ostov)
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/sandbox/CMakeLists.txt")
-    add_subdirectory(sandbox)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt")
+    add_subdirectory(examples)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# ostov
+# Ostov
 
-**ostov** is a production-grade, reusable **Render Graph Middleware** for OpenGL 4.6+, geared towards Technical Artists and Engine Developers.
+## What is Ostov
 
-*"Ostov"* (Russian: Остов) means *Skeleton* or *Frame*—the indestructible hull that remains when the walls are stripped away.
+Ostov is a production-grade, reusable render graph middleware for OpenGL 4.6+.
 
-## Philosophy
+## Why Ostov
 
-Most "Game Engines" are bloated with physics, audio, and ECS. **Ostov** is different. It is a specialized **Graphics Abstraction Layer**.
-
-It transforms spaghetti OpenGL calls (`glBindBuffer`, `glVertexAttribPointer`) into a structured, high-level **Render Graph**:
+Most Game Engines are bloated with physics, audio, and ECS. Ostov is here to save the day. It is a specialized graphics abstraction layer that transforms spaghetti OpenGL calls into a structured, high-level render graph:
 
 ```cpp
 auto& geometryPass = renderGraph.AddPass("Geometry");
@@ -18,7 +16,7 @@ geometryPass.Execute = [&](Renderer& r) {
 };
 ```
 
-## Key Features (Planning)
+## Key Features (Under development)
 
 - **Render Graph Architecture:** Define complex frame pipelines (G-Buffer -> Shadow -> Lighting -> Bloom) as a dependency graph.
 - **Direct State Access (DSA):** Built strictly on OpenGL 4.6 DSA for cleaner, safer, faster state management.
@@ -28,14 +26,12 @@ geometryPass.Execute = [&](Renderer& r) {
 
 ## Structure
 
-- **ostov/**: The Static Library (Middleware).
-- **sandbox/**: A client application demonstrating how to build a renderer on top of Ostov.
+- `ostov/`: The Static Library (Middleware).
+- `examples/`: A client application demonstrating how to build a renderer on top of Ostov.
 
-## Building
+## Build and Run
 
 ```bash
-mkdir build
-cd build
-cmake ..
-cmake --build .
+cmake -S . -B build ; cmake --build build
+# .\build\bin\examples_app.exe
 ```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(examples)
+
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+
+add_executable(examples_app ${SOURCES})
+
+target_link_libraries(examples_app PRIVATE ostov)
+
+set_target_properties(examples_app PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/examples")

--- a/examples/src/ExampleApp.cpp
+++ b/examples/src/ExampleApp.cpp
@@ -1,0 +1,123 @@
+#include <ostov/ostov.h>
+#include <GLFW/glfw3.h>
+#include <iostream>
+#include <glm/gtc/matrix_transform.hpp>
+#include <cmath>
+
+class ExampleApp : public Ostov::Application {
+public:
+    ExampleApp() {
+        std::cout << "Example App Created!\n";
+    }
+
+    ~ExampleApp() {
+    }
+
+    void OnInit() override {
+        std::cout << "ExampleApp::OnInit() - Generating Sphere...\n";
+
+        // 1. 手动生成圆球顶点数据 (体现使用者的控制力)
+        std::vector<Ostov::Vertex> vertices;
+        std::vector<uint32_t> indices;
+        
+        const float radius = 0.8f;
+        const int sectors = 36;
+        const int stacks = 18;
+        const float PI = 3.14159265359f;
+
+        for (int i = 0; i <= stacks; ++i) {
+            float stackAngle = PI / 2 - i * PI / stacks;
+            float xy = radius * cosf(stackAngle);
+            float z = radius * sinf(stackAngle);
+
+            for (int j = 0; j <= sectors; ++j) {
+                float sectorAngle = j * 2 * PI / sectors;
+                float x = xy * cosf(sectorAngle);
+                float y = xy * sinf(sectorAngle);
+
+                Ostov::Vertex v;
+                v.Position = { x, y, z };
+                v.Normal = glm::normalize(v.Position);
+                v.TexCoord = { (float)j / sectors, (float)i / stacks };
+                vertices.push_back(v);
+            }
+        }
+
+        for (int i = 0; i < stacks; ++i) {
+            int k1 = i * (sectors + 1);
+            int k2 = k1 + sectors + 1;
+            for (int j = 0; j < sectors; ++j, ++k1, ++k2) {
+                if (i != 0) {
+                    indices.push_back(k1);
+                    indices.push_back(k2);
+                    indices.push_back(k1 + 1);
+                }
+                if (i != (stacks - 1)) {
+                    indices.push_back(k1 + 1);
+                    indices.push_back(k2);
+                    indices.push_back(k2 + 1);
+                }
+            }
+        }
+
+        m_SphereMesh = std::make_unique<Ostov::Mesh>(vertices, indices);
+
+        // 2. 创建一个简单的 Shader (显示法线颜色)
+        std::string vShader = R"(
+            #version 330 core
+            layout (location = 0) in vec3 aPos;
+            layout (location = 1) in vec3 aNormal;
+            uniform mat4 u_ViewProj;
+            out vec3 vNormal;
+            void main() {
+                vNormal = aNormal;
+                gl_Position = u_ViewProj * vec4(aPos, 1.0);
+            }
+        )";
+
+        std::string fShader = R"(
+            #version 330 core
+            in vec3 vNormal;
+            out vec4 FragColor;
+            void main() {
+                // 将法线 [-1, 1] 映射到 [0, 1] 显示颜色
+                FragColor = vec4(vNormal * 0.5 + 0.5, 1.0);
+            }
+        )";
+
+        m_Shader = std::make_unique<Ostov::Shader>(vShader, fShader);
+
+        // 3. 配置 RenderGraph
+        auto& geometryPass = m_RenderGraph.AddPass("Geometry");
+        geometryPass.Execute = [&](Ostov::Renderer& r) {
+            r.SetClearColor({ 0.1f, 0.1f, 0.1f, 1.0f });
+            r.Clear();
+            r.SetDepthTest(true);
+
+            m_Shader->Bind();
+            
+            // 简单的旋转投影矩阵
+            float time = (float)glfwGetTime();
+            glm::mat4 view = glm::translate(glm::mat4(1.0f), glm::vec3(0, 0, -3));
+            glm::mat4 proj = glm::perspective(glm::radians(45.0f), 640.0f/480.0f, 0.1f, 100.0f);
+            glm::mat4 model = glm::rotate(glm::mat4(1.0f), time, glm::vec3(0, 1, 0));
+            
+            m_Shader->SetUniformMat4("u_ViewProj", proj * view * model);
+            
+            r.Submit(*m_SphereMesh);
+        };
+    }
+
+    void OnUpdate() override {
+        m_RenderGraph.Execute();
+    }
+
+private:
+    Ostov::RenderGraph m_RenderGraph;
+    std::unique_ptr<Ostov::Mesh> m_SphereMesh;
+    std::unique_ptr<Ostov::Shader> m_Shader;
+};
+
+Ostov::Application* Ostov::CreateApplication() {
+    return new ExampleApp();
+}

--- a/ostov/include/ostov/Mesh.h
+++ b/ostov/include/ostov/Mesh.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+#include <glm/glm.hpp>
+
+namespace Ostov {
+
+    struct Vertex {
+        glm::vec3 Position;
+        glm::vec3 Normal;
+        glm::vec2 TexCoord;
+    };
+
+    class Mesh {
+    public:
+        Mesh(const std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices);
+        ~Mesh();
+
+        // OpenGL handles (will be managed internally)
+        uint32_t GetVAO() const { return m_VAO; }
+        uint32_t GetIndexCount() const { return static_cast<uint32_t>(m_Indices.size()); }
+
+    private:
+        void SetupMesh();
+
+        std::vector<Vertex> m_Vertices;
+        std::vector<uint32_t> m_Indices;
+        uint32_t m_VAO = 0, m_VBO = 0, m_EBO = 0;
+    };
+
+}

--- a/ostov/include/ostov/RenderGraph.h
+++ b/ostov/include/ostov/RenderGraph.h
@@ -1,18 +1,13 @@
 #pragma once
 
 #include "core.h"
+#include "Renderer.h"
 #include <string>
 #include <vector>
 #include <functional>
 #include <map>
 
 namespace Ostov {
-
-    // Simple placeholder for Renderer
-    class Renderer {
-    public:
-        void DrawMesh() { /* TODO */ }
-    };
 
     struct RenderPass {
         std::string Name;

--- a/ostov/include/ostov/Renderer.h
+++ b/ostov/include/ostov/Renderer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Mesh.h"
+#include <glm/glm.hpp>
+
+namespace Ostov {
+
+    class Renderer {
+    public:
+        Renderer();
+        ~Renderer();
+
+        // 这里就是解决你疑问的关键：
+        // 渲染器不决定圆球长什么样，它只负责把用户准备好的 Mesh (顶点) 投影到屏幕上。
+        void Submit(const Mesh& mesh);
+
+        // 状态设置：集中管理 OpenGL 状态，防止乱码
+        void SetClearColor(const glm::vec4& color);
+        void Clear();
+
+        void SetDepthTest(bool enabled);
+        
+    private:
+        // 可以在这里做状态缓存 (State Caching)
+    };
+
+}

--- a/ostov/include/ostov/Shader.h
+++ b/ostov/include/ostov/Shader.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <glm/glm.hpp>
+
+namespace Ostov {
+
+    class Shader {
+    public:
+        Shader(const std::string& vertexSrc, const std::string& fragmentSrc);
+        ~Shader();
+
+        void Bind() const;
+        void Unbind() const;
+
+        void SetUniformFloat4(const std::string& name, const glm::vec4& value);
+        void SetUniformMat4(const std::string& name, const glm::mat4& value);
+
+    private:
+        uint32_t m_RendererID;
+    };
+
+}

--- a/ostov/include/ostov/ostov.h
+++ b/ostov/include/ostov/ostov.h
@@ -3,6 +3,9 @@
 // For use by Ostov applications
 #include <ostov/application.h>
 #include <ostov/core.h>
+#include <ostov/Renderer.h>
+#include <ostov/Mesh.h>
+#include <ostov/Shader.h>
 #include <ostov/RenderGraph.h>
 
 // Entry Point

--- a/ostov/src/Mesh.cpp
+++ b/ostov/src/Mesh.cpp
@@ -1,0 +1,46 @@
+#include <ostov/Mesh.h>
+#include <glad/glad.h>
+
+namespace Ostov {
+
+    Mesh::Mesh(const std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices)
+        : m_Vertices(vertices), m_Indices(indices) 
+    {
+        SetupMesh();
+    }
+
+    Mesh::~Mesh() {
+        glDeleteVertexArrays(1, &m_VAO);
+        glDeleteBuffers(1, &m_VBO);
+        glDeleteBuffers(1, &m_EBO);
+    }
+
+    void Mesh::SetupMesh() {
+        glGenVertexArrays(1, &m_VAO);
+        glGenBuffers(1, &m_VBO);
+        glGenBuffers(1, &m_EBO);
+
+        glBindVertexArray(m_VAO);
+
+        glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
+        glBufferData(GL_ARRAY_BUFFER, m_Vertices.size() * sizeof(Vertex), m_Vertices.data(), GL_STATIC_DRAW);
+
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_EBO);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_Indices.size() * sizeof(uint32_t), m_Indices.data(), GL_STATIC_DRAW);
+
+        // Position
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, Position));
+
+        // Normal
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, Normal));
+
+        // TexCoords
+        glEnableVertexAttribArray(2);
+        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, TexCoord));
+
+        glBindVertexArray(0);
+    }
+
+}

--- a/ostov/src/Renderer.cpp
+++ b/ostov/src/Renderer.cpp
@@ -1,0 +1,30 @@
+#include <ostov/Renderer.h>
+#include <glad/glad.h>
+
+namespace Ostov {
+
+    Renderer::Renderer() {
+    }
+
+    Renderer::~Renderer() {
+    }
+
+    void Renderer::SetClearColor(const glm::vec4& color) {
+        glClearColor(color.r, color.g, color.b, color.a);
+    }
+
+    void Renderer::Clear() {
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    }
+
+    void Renderer::SetDepthTest(bool enabled) {
+        if (enabled) glEnable(GL_DEPTH_TEST);
+        else glDisable(GL_DEPTH_TEST);
+    }
+
+    void Renderer::Submit(const Mesh& mesh) {
+        glBindVertexArray(mesh.GetVAO());
+        glDrawElements(GL_TRIANGLES, mesh.GetIndexCount(), GL_UNSIGNED_INT, 0);
+    }
+
+}

--- a/ostov/src/Shader.cpp
+++ b/ostov/src/Shader.cpp
@@ -1,0 +1,89 @@
+#include <ostov/Shader.h>
+#include <glad/glad.h>
+#include <glm/gtc/type_ptr.hpp>
+#include <iostream>
+#include <vector>
+
+namespace Ostov {
+
+    Shader::Shader(const std::string& vertexSrc, const std::string& fragmentSrc) {
+        GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
+        const GLchar* source = vertexSrc.c_str();
+        glShaderSource(vertexShader, 1, &source, 0);
+        glCompileShader(vertexShader);
+
+        GLint isCompiled = 0;
+        glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &isCompiled);
+        if (isCompiled == GL_FALSE) {
+            GLint maxLength = 0;
+            glGetShaderiv(vertexShader, GL_INFO_LOG_LENGTH, &maxLength);
+            std::vector<GLchar> infoLog(maxLength);
+            glGetShaderInfoLog(vertexShader, maxLength, &maxLength, &infoLog[0]);
+            glDeleteShader(vertexShader);
+            std::cout << "Vertex Shader Compilation Failed:\n" << &infoLog[0] << std::endl;
+            return;
+        }
+
+        GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+        source = fragmentSrc.c_str();
+        glShaderSource(fragmentShader, 1, &source, 0);
+        glCompileShader(fragmentShader);
+
+        glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &isCompiled);
+        if (isCompiled == GL_FALSE) {
+            GLint maxLength = 0;
+            glGetShaderiv(fragmentShader, GL_INFO_LOG_LENGTH, &maxLength);
+            std::vector<GLchar> infoLog(maxLength);
+            glGetShaderInfoLog(fragmentShader, maxLength, &maxLength, &infoLog[0]);
+            glDeleteShader(fragmentShader);
+            glDeleteShader(vertexShader);
+            std::cout << "Fragment Shader Compilation Failed:\n" << &infoLog[0] << std::endl;
+            return;
+        }
+
+        m_RendererID = glCreateProgram();
+        glAttachShader(m_RendererID, vertexShader);
+        glAttachShader(m_RendererID, fragmentShader);
+        glLinkProgram(m_RendererID);
+
+        GLint isLinked = 0;
+        glGetProgramiv(m_RendererID, GL_LINK_STATUS, &isLinked);
+        if (isLinked == GL_FALSE) {
+            GLint maxLength = 0;
+            glGetProgramiv(m_RendererID, GL_INFO_LOG_LENGTH, &maxLength);
+            std::vector<GLchar> infoLog(maxLength);
+            glGetProgramInfoLog(m_RendererID, maxLength, &maxLength, &infoLog[0]);
+            glDeleteProgram(m_RendererID);
+            glDeleteShader(vertexShader);
+            glDeleteShader(fragmentShader);
+            std::cout << "Shader Link Failed:\n" << &infoLog[0] << std::endl;
+            return;
+        }
+
+        glDetachShader(m_RendererID, vertexShader);
+        glDetachShader(m_RendererID, fragmentShader);
+    }
+
+    Shader::~Shader() {
+        glDeleteProgram(m_RendererID);
+    }
+
+    void Shader::Bind() const {
+        glUseProgram(m_RendererID);
+    }
+
+    void Shader::Unbind() const {
+        glUseProgram(0);
+    }
+
+    void Shader::SetUniformFloat4(const std::string& name, const glm::vec4& value) {
+        GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+        glUniform4f(location, value.x, value.y, value.z, value.w);
+    }
+
+    void Shader::SetUniformMat4(const std::string& name, const glm::mat4& value) {
+        GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+        glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(value));
+    }
+
+}


### PR DESCRIPTION
## What?

- Renamed the `sandbox/` directory to `examples/` and updated the project structure.
- Renamed the client application from `Sandbox` to `ExampleApp`.
- Integrated foundational rendering components into the core library: `Renderer`, `Mesh`, `Shader`, and `RenderGraph`.
- Updated `CMakeLists.txt`, `.gitignore`, `.gitattributes`, and `README.md` to reflect these changes.

## Why?

- To transition the repository toward a professional-grade middleware structure.
- To provide clear, well-organized usage examples for researchers and developers.
- To improve GitHub language statistics by properly categorizing example code and vendored dependencies.

## How?

- Moved files and updated CMake targets to ensure the `examples_app` links correctly against the ostov static library.
- Implied a rotating sphere demonstration in `ExampleApp.cpp` using the newly implemented Render Graph system.

## Testing?

- Successfully built the project using CMake (Ninja generator) on Windows.
- Verified that `examples_app.exe` launches correctly and renders the 3D sphere as expected.
- Confirmed there are no linking or include path regressions.

## Screenshots (optional)

None.

## Anything Else?

This PR made some clean-ups and includes a sandbox-like example to showcase.